### PR TITLE
change wrong executable name to VOCRelease5 to detect objects

### DIFF
--- a/pcloudcv/ObjectDetection.ipynb
+++ b/pcloudcv/ObjectDetection.ipynb
@@ -40,7 +40,7 @@
      "input": [
       "import os\n",
       "config_path = os.path.join(os.getcwd(), 'config.json') #full path of the config.json file\n",
-      "dict = {'exec': 'ImageStitch'}"
+      "dict = {'exec': 'VOCRelease5'}"
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
Wrong executable name in ipython notebook- "ObjectDetection.ipynb".
Changed to VOCRelease5.