### PR TITLE
modify ipython notebooks to fix the following bugs

### DIFF
--- a/pcloudcv/Classification Visualization.ipynb
+++ b/pcloudcv/Classification Visualization.ipynb
@@ -27,7 +27,7 @@
       "from IPython.display import Image\n",
       "from IPython.display import HTML\n",
       "import json\n",
-      "import os"
+      "import os, signal"
      ],
      "language": "python",
      "metadata": {},
@@ -46,7 +46,7 @@
      "collapsed": false,
      "input": [
       "config_path = os.path.join(os.getcwd(), 'config.json') #full path of the config.json file\n",
-      "dict = {'exec': 'classify'}"
+      "dict = {'exec': 'classify'} #executable name"
      ],
      "language": "python",
      "metadata": {},
@@ -64,7 +64,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Starting the CloudCV is as easy initializing the class with the config file path, dictionary containing parameters and a flag specifying whether to login through google or not.\n"
+      "Starting the CloudCV is as easy as initializing the class with the config file path, dictionary containing parameters and a flag specifying whether to login through google or not.\n"
      ]
     },
     {
@@ -72,7 +72,9 @@
      "collapsed": false,
      "input": [
       "p = PCloudCV(config_path, dict, True)\n",
-      "p.start()"
+      "signal.signal(signal.SIGINT, p.signal_handler)\n",
+      "p.start()\n",
+      "signal.pause()"
      ],
      "language": "python",
      "metadata": {},
@@ -80,7 +82,7 @@
     },
     {
      "cell_type": "heading",
-     "level": 1,
+     "level": 2,
      "metadata": {},
      "source": [
       "Visualize Results Here"

--- a/pcloudcv/FeatureExtraction.ipynb
+++ b/pcloudcv/FeatureExtraction.ipynb
@@ -19,7 +19,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "from pcloudcv import PCloudCV\n"
+      "from pcloudcv import PCloudCV"
      ],
      "language": "python",
      "metadata": {},
@@ -29,9 +29,9 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "import os\n",
-      "config_path = os.path.join(os.getcwd(), 'config.json') #full path of the config.json file\n",
-      "dict = {'exec': 'features'}"
+      "import os, signal\n",
+      "config_path = os.path.join(os.getcwd(), 'config.json') #full path of the file config.json file\n",
+      "dict = {'exec': 'features'} #executable name"
      ],
      "language": "python",
      "metadata": {},
@@ -41,7 +41,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Starting the CloudCV is as easy initializing the class with the config file path, dictionary containing parameters and a flag specifying whether to login through google or not.\n"
+      "Starting the CloudCV is as easy as initializing the class with the config file path, dictionary containing parameters and a flag specifying whether to login through google or not.\n"
      ]
     },
     {
@@ -49,6 +49,7 @@
      "collapsed": false,
      "input": [
       "p = PCloudCV(config_path, dict, True)\n",
+      "signal.signal(signal.SIGINT, p.signal_handler)\n",
       "p.start()"
      ],
      "language": "python",
@@ -59,7 +60,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "exit"
+      "signal.pause()"
      ],
      "language": "python",
      "metadata": {},

--- a/pcloudcv/FeatureExtraction.ipynb
+++ b/pcloudcv/FeatureExtraction.ipynb
@@ -9,7 +9,8 @@
   {
    "cells": [
     {
-     "cell_type": "markdown",
+     "cell_type": "heading",
+     "level": 2,
      "metadata": {},
      "source": [
       "Start by importing PCloudCV module to run Python API for cloudcv"
@@ -19,23 +20,39 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "from pcloudcv import PCloudCV"
+      "from pcloudcv import PCloudCV\n",
+      "import os, signal"
      ],
      "language": "python",
      "metadata": {},
      "outputs": []
     },
     {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Load the configuration file and mention the function you wish to run"
+     ]
+    },
+    {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "import os, signal\n",
       "config_path = os.path.join(os.getcwd(), 'config.json') #full path of the file config.json file\n",
       "dict = {'exec': 'features'} #executable name"
      ],
      "language": "python",
      "metadata": {},
      "outputs": []
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Start CloudCV Thread"
+     ]
     },
     {
      "cell_type": "markdown",
@@ -50,16 +67,7 @@
      "input": [
       "p = PCloudCV(config_path, dict, True)\n",
       "signal.signal(signal.SIGINT, p.signal_handler)\n",
-      "p.start()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
+      "p.start()\n",
       "signal.pause()"
      ],
      "language": "python",


### PR DESCRIPTION
Fixes this error while running the code in notebooks by adding signal.pause() after starting CloudCV thread-
```bash
(cloudcv_env)SnShine (experiment): py one.py
Added Path: /home/suryateja/pcloudcv/pcloudcv
CherryPy Checker:
The Application mounted at '' has an empty config.

Starting Listening to Redis Channel for HTTP Post Requests

Listening to Redis Channel

/home/suryateja/pcloudcv/pcloudcv/config.cfg
770a1f4e-cf06-11e4-b35f-22000aef83c4
User Authenticated
Welcome Surya
Starting Socket Connection Thread

SocketID:  8AX8WCRmgG5FVeDpIDt-
Starting Post Request

/home/suryateja/cloudcv_env/local/lib/python2.7/site-packages/cherrypy/process/wspbus.py:233: RuntimeWarning: The main thread is exiting, but the Bus is in the states.STARTED state; shutting it down automatically now. You must either call bus.block() after start(), or call bus.exit() before the main thread exits.
  "main thread exits." % self.state, RuntimeWarning)
```